### PR TITLE
Restrict sudo commands

### DIFF
--- a/nix/dbx/dogeboxd.nix
+++ b/nix/dbx/dogeboxd.nix
@@ -94,7 +94,11 @@
       users = [ "dogeboxd" ];
       commands = [
         {
-          command = "ALL";
+          command = "${dogeboxd}/bin/_dbxroot";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/wrappers/bin/_dbxroot";
           options = [ "NOPASSWD" ];
         }
       ];


### PR DESCRIPTION
Restrict dogeboxd user's sudo commands to just _dbxroot wrapper.