### PR TITLE
Release Dogebox OS v0.4.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745585544,
-        "narHash": "sha256-oB5pX8dXVN6HvrUAdkDKEW6NNAShc+O0JYFc6zAdlZI=",
+        "lastModified": 1748839988,
+        "narHash": "sha256-spvltAArU1EsfvaQQ/7xUlUv0mSdeKEIXjyt67kwRpI=",
         "owner": "dogebox-wg",
         "repo": "dkm",
-        "rev": "fe17a45f030539737af43f596ed93a3f57fd7d93",
+        "rev": "61eb4c846d61049ab0c821122ac2fb889b28d94c",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743053841,
-        "narHash": "sha256-+Z+Af4hgI63L4u+ty4v2iEzPAqlqVAt6UdKE0YD+rXE=",
+        "lastModified": 1750056416,
+        "narHash": "sha256-AsXDH/z604Gq081dbq8SIbKVNAUo8mukdUgrvzEtSKY=",
         "owner": "dogebox-wg",
         "repo": "dogebox-nur-packages",
-        "rev": "3b055551fa069781492283a6eb8b590cfe36e8c5",
+        "rev": "e142d43fd7086e126b7c114b4cee7470fe0cdbfc",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745798979,
-        "narHash": "sha256-arN6LJDxGEI1VyYgKEX/HpDaa192wUPKnO33hDb55io=",
+        "lastModified": 1750213277,
+        "narHash": "sha256-8QuPSYp8ikGpKc2O/oD2IaFoSPoiwpnpXWsnbnBZ7lE=",
         "owner": "dogebox-wg",
         "repo": "dogeboxd",
-        "rev": "1e364497a0239ed8a2860004cb907d4beff0446a",
+        "rev": "57de5ed3aabb04156233dc104908cdab36740b3c",
         "type": "github"
       },
       "original": {
@@ -76,14 +76,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "playwright": "playwright"
       },
       "locked": {
-        "lastModified": 1745385969,
-        "narHash": "sha256-okGVhPstOjVQ/udQDwHkWWobRTPA5Gz7OMZBzJzOECs=",
+        "lastModified": 1750226221,
+        "narHash": "sha256-jig5YYRg6iBur/LIb0SU3DNu6AUh3Hajk5JcCU2Uggg=",
         "owner": "dogebox-wg",
         "repo": "dpanel",
-        "rev": "ef3287781fca203740faeecf63b384bcc0bd5c29",
+        "rev": "52c7ab23dba8e2836cdba9edb7e01b2558fca130",
         "type": "github"
       },
       "original": {
@@ -111,6 +112,24 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -170,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742568034,
-        "narHash": "sha256-QaMEhcnscfF2MqB7flZr+sLJMMYZPnvqO4NYf9B4G38=",
+        "lastModified": 1747663185,
+        "narHash": "sha256-Obh50J+O9jhUM/FgXtI3he/QRNiV9+J53+l+RlKSaAk=",
         "owner": "nix-community",
         "repo": "nixos-generators",
-        "rev": "42ee229088490e3777ed7d1162cb9e9d8c3dbb11",
+        "rev": "ee07ba0d36c38e9915c55d2ac5a8fb0f05f2afcc",
         "type": "github"
       },
       "original": {
@@ -185,17 +204,48 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745487689,
-        "narHash": "sha256-FQoi3R0NjQeBAsEOo49b5tbDPcJSMWc3QhhaIi9eddw=",
+        "lastModified": 0,
+        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
+        "path": "/nix/store/0283cbhm47kd3lr9zmc5fvdrx9qkav8s-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1750151854,
+        "narHash": "sha256-3za+1J9FifMetO7E/kwgyW+dp+8pPBNlWKfcBovnn6M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5630cf13cceac06cefe9fc607e8dfa8fb342dde3",
+        "rev": "ad5c70bcc5cc5178205161b7a7d61a6e80f6d244",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-24.11",
         "type": "indirect"
+      }
+    },
+    "playwright": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1744969290,
+        "narHash": "sha256-8pMFEdOT83u4VAIbnGOfnHvv5jNfRqZOnYjtQJaXkTs=",
+        "owner": "pietdevries94",
+        "repo": "playwright-web-flake",
+        "rev": "ceda34e26f2d0a939346c5d456afe69c9cf5250f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pietdevries94",
+        "repo": "playwright-web-flake",
+        "type": "github"
       }
     },
     "pre-commit-hooks": {
@@ -207,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1749636823,
+        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
         "type": "github"
       },
       "original": {
@@ -226,13 +276,28 @@
         "dogebox-nur-packages": "dogebox-nur-packages",
         "dogeboxd": "dogeboxd",
         "dpanel": "dpanel",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixos-generators": "nixos-generators",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
       ...
     }@inputs:
     let
-      dbxRelease = "v0.3.2-beta.3";
+      dbxRelease = "v0.4.0";
 
       builderBases = {
         iso = ./nix/builders/iso/base.nix;


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/dogeorg/dogebox/raw/main/docs/img/dogebox-logo.png" alt="Dogebox Logo"/>
  <p>DOGEBOX is a NixOS distribution that runs the Dogebox Runtime Environment</p>
</div>

> [!CAUTION]  
> # Warning
> Dogebox is currently in beta (heavy testing). Do not use it for any production workloads, and definitely don't send any money to addresses generated by it unless you have ensured key backups.

This release contains updates to the way we develop dogebox and build the operating system as well as plenty of updates to Dogeboxd, Dpanel, and other packages.

We have also focused on getting Wi-Fi capability working and making the installation process smoother and quicker.

## What's Changed
* Update to NixOS 24.11 by @SomeoneWeird in https://github.com/Dogebox-WG/os/pull/10
* Add avahi daemon to publish mdns record for dogebox.local by @DivineGod in https://github.com/Dogebox-WG/os/pull/11
* add wirelesstools to dogebox base by @DivineGod in https://github.com/Dogebox-WG/os/pull/12
* wifi networking setup on dogebox hardware by @DivineGod in https://github.com/Dogebox-WG/os/pull/16
* Update DEVELOPMENT.md by @benfinix in https://github.com/Dogebox-WG/os/pull/15
* OS Flake by @SomeoneWeird in https://github.com/Dogebox-WG/os/pull/19
* revert part of previous wifi commit by @DivineGod in https://github.com/Dogebox-WG/os/pull/18
* start dogeboxd when we are actually online by @DivineGod in https://github.com/Dogebox-WG/os/pull/27

## New Contributors 
* @DivineGod made their first contribution in https://github.com/Dogebox-WG/os/pull/11
* @benfinix made their first contribution in https://github.com/Dogebox-WG/os/pull/15

**Full Changelog**: https://github.com/Dogebox-WG/os/compare/v0.3.2-beta.3...v0.4.0